### PR TITLE
Record responder user

### DIFF
--- a/base/centro_estudiantes.sql
+++ b/base/centro_estudiantes.sql
@@ -37,7 +37,11 @@ CREATE TABLE mensajes_contacto (
     nombre VARCHAR(100) NOT NULL,
     email VARCHAR(100) NOT NULL,
     mensaje TEXT NOT NULL,
-    fecha_envio DATETIME DEFAULT CURRENT_TIMESTAMP
+    respuesta TEXT,
+    fecha_envio DATETIME DEFAULT CURRENT_TIMESTAMP,
+    fecha_respuesta DATETIME,
+    id_usuario_respuesta INT,
+    FOREIGN KEY (id_usuario_respuesta) REFERENCES usuarios(id)
 );
 
 -- Insertar usuario administrador de prueba (clave: admin123, hasheada con password_hash en PHP)

--- a/scripts/dashboard.php
+++ b/scripts/dashboard.php
@@ -24,7 +24,7 @@ $mensaje = isset($_GET['mensaje']) ? $_GET['mensaje'] : null;
 
 // Traer mensajes del formulario de contacto
 try {
-    $stmt_mensajes = $pdo->query("SELECT * FROM mensajes_contacto ORDER BY fecha_envio DESC");
+    $stmt_mensajes = $pdo->query("SELECT m.*, u.nombre_usuario AS respondido_por FROM mensajes_contacto m LEFT JOIN usuarios u ON m.id_usuario_respuesta = u.id ORDER BY m.fecha_envio DESC");
     $mensajes_contacto = $stmt_mensajes->fetchAll();
 } catch (PDOException $e) {
     die("Error al obtener mensajes: " . $e->getMessage());
@@ -143,6 +143,7 @@ try {
             <th>Mensaje</th>
             <th>Fecha</th>
             <th>Respuesta</th>
+            <th>Respondido por</th>
             <th>Acciones</th>
         </tr>
     </thead>
@@ -154,6 +155,7 @@ try {
             <td><?= nl2br(htmlspecialchars($msg['mensaje'])) ?></td>
             <td><?= $msg['fecha_envio'] ?></td>
             <td><?= $msg['respuesta'] ? nl2br(htmlspecialchars($msg['respuesta'])) : 'Sin responder' ?></td>
+            <td><?= htmlspecialchars($msg['respondido_por'] ?? '') ?></td>
             <td>
                 <a href="responder_mensaje.php?id=<?= $msg['id'] ?>">Responder</a>
             </td>

--- a/scripts/responder_mensaje.php
+++ b/scripts/responder_mensaje.php
@@ -45,8 +45,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if ($mensaje) {
         // Actualizar la respuesta en la base de datos
-        $stmt = $pdo->prepare("UPDATE mensajes_contacto SET respuesta = ?, fecha_respuesta = NOW() WHERE id = ?");
-        $stmt->execute([$respuesta, $id]);
+        $stmt = $pdo->prepare("UPDATE mensajes_contacto SET respuesta = ?, fecha_respuesta = NOW(), id_usuario_respuesta = ? WHERE id = ?");
+        $stmt->execute([$respuesta, $_SESSION['usuario_id'], $id]);
 
         $mail = new PHPMailer(true);
         try {


### PR DESCRIPTION
## Summary
- track the user who responds to messages
- show responder info in the dashboard
- update the example schema accordingly

## Testing
- `php -l scripts/responder_mensaje.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c9b6359c0832aa421dfd80e6b0d2c