### PR TITLE
Fix header logo layout

### DIFF
--- a/estilos/estilosindex.css
+++ b/estilos/estilosindex.css
@@ -17,6 +17,12 @@ header {
     background-color: var(--verde-oscuro);
     color: var(--blanco);
     padding: 1rem;
+    flex-wrap: wrap; /* Permite que los elementos se ajusten en pantallas estrechas */
+}
+
+.headertitulo {
+    flex: 1;
+    text-align: center;
 }
 
 h1 {
@@ -29,9 +35,7 @@ h2{
 header img{
     width: 100px;
     height: 120px;
-    margin-left: 50px;
-    margin-right: 50px;
-
+    margin: 0 1rem;
 }
 
 /* === Barra Lateral === */


### PR DESCRIPTION
## Summary
- allow header contents to wrap and center title
- reduce header logo margins to prevent overflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686298def79c832a8a8983fe292b35a4